### PR TITLE
ppx_bitstring >= 1.3.3

### DIFF
--- a/opam
+++ b/opam
@@ -15,7 +15,7 @@ install: [[ "omake" "install" "PREFIX=%{prefix}%" ]]
 remove: [[ "omake" "uninstall" ]]
 
 depends: [
-  "ppx_bitstring"
+  "ppx_bitstring" {>= "1.3.3"}
   "camlzip"
   "omake"        {build}
   "ocamlfind"    {build}


### PR DESCRIPTION
In clean environment (just after `opam switch`), `opam pin add obeam .` will be failed because `ppx_bitstring.1.1.0` will be installed.

So this pull-request restricts `ppx_bitstring` version to `>= 1.3.3`.