### PR TITLE
fix parse_etf about   (* 12.16 BINARY_EXT *)

### DIFF
--- a/lib/external_term_format.ml
+++ b/lib/external_term_format.ml
@@ -126,8 +126,8 @@ let rec parse_etf (_, buf) =
 
   (* 12.16 BINARY_EXT *)
   | {| 109   : 1*8
-     ; len   : 2*8
-     ; data  : len*8 : bitstring
+     ; len   : 4*8
+     ; data  : Int32.to_int len * 8 : bitstring
      ; rest  : -1 : bitstring
      |} ->
      Ok (Binary data, rest)


### PR DESCRIPTION
## The Bug
The length field of BINARY_EXT is an unsigned 4 byte integer, but the ml code expected 2 byte integer.

- http://erlang.org/doc/apps/erts/erl_ext_dist.html#binary_ext

## This Pull Request

fix the bug.