### PR TITLE
Support wild attribute

### DIFF
--- a/lib/abstract_format.ml
+++ b/lib/abstract_format.ml
@@ -32,7 +32,7 @@ and form_t =
   | DeclRecord of line_t * (line_t * string * expr_t option * type_t option) list
   | DeclType of line_t * string * (line_t * string) list * type_t
   | DeclOpaqueType of line_t * string * (line_t * string) list * type_t
-  | AttrWild
+  | AttrWild of line_t * string * Sf.t
 
   | FormEof
 
@@ -213,6 +213,13 @@ and form_of_sf sf =
                                ]);
                  ]) ->
     DeclOpaqueType (line, name, tvars |> List.map tvar_of_sf, type_of_sf t)
+
+  (* wild attribute *)
+  | Sf.Tuple (4, [Sf.Atom "attribute";
+                  Sf.Integer line;
+                  Sf.Atom attr;
+                  term]) ->
+     AttrWild (line, attr, term)
 
   (* eof *)
   | Sf.Tuple (2, [Sf.Atom "eof"; Sf.Integer line]) ->

--- a/test/abs_form_test.ml
+++ b/test/abs_form_test.ml
@@ -349,6 +349,40 @@ let template_05 () =
          Ast.FormEof])
   )
 
+let template_06 () =
+  let module Ast = Obeam.Abstract_format in
+  let module Sf = Obeam.Simple_term_format in
+  ("test06.erl",
+   Ast.AbstractCode
+     (Ast.ModDecl
+        [(Ast.AttrFile (1, "test06.erl", 1));
+         (Ast.AttrMod (1, "test06"));
+         (Ast.AttrWild (3, "compile",
+                        (Sf.List [(Sf.Atom "export_all")])
+         ));
+         (Ast.AttrWild (5, "vsn",
+                        (Sf.Atom "1.0.0")));
+         (Ast.AttrWild (7, "on_load",
+                        (Sf.Tuple (2,
+                                   [(Sf.Atom "f"); (Sf.Integer 0)]
+                        ))
+         ));
+         (Ast.AttrWild (9, "behaviour",
+                        (Sf.Atom "gen_server")));
+         (Ast.AttrWild (11, "foo",
+                        (Sf.Binary "bar")));
+         (Ast.DeclFun (13, "f", 0,
+                       [(Ast.ClsFun (13, [], None,
+                                     (Ast.ExprBody
+                                        [(Ast.ExprLit
+                                            (Ast.LitAtom (13, "ok")))
+                                     ])
+                        ))
+                       ]
+         ));
+         Ast.FormEof])
+  )
+
 let rec suite =
   "parse_abs_form_in_beam_suite" >:::
     [
@@ -357,6 +391,7 @@ let rec suite =
       "template_03" >:: assert_equals_abs_form_f template_03;
       "template_04" >:: assert_equals_abs_form_f template_04;
       "template_05" >:: assert_equals_abs_form_f template_05;
+      "template_06" >:: assert_equals_abs_form_f template_06;
     ]
 
 let () =

--- a/test/test06.erl
+++ b/test/test06.erl
@@ -1,0 +1,13 @@
+-module(test06).
+
+-compile([export_all]).
+
+-vsn('1.0.0').
+
+-on_load(f/0).
+
+-behaviour(gen_server).
+
+-foo(<<"bar">>).
+
+f() -> ok.


### PR DESCRIPTION
I added support for wild attribute.

ref:

http://erlang.org/doc/apps/erts/absform.html

> If F is a wild attribute -A(T), then Rep(F) = {attribute,LINE,A,T}.

In this document, `T` means `Type` form. However, the `T` of wild attribute seems to mean any `Term` (not absform's `expr` or `literal` but erlang raw term). 😢 

http://erlang.org/pipermail/erlang-questions/2017-January/091482.html

> * "Wild" Attributes (as they were named in the draft Standard Erlang
> specification) - any attribute that is not one of the Declarations, and has
> the form '-Atom(Term)' - note that only one argument is allowed. These can
> occur anywhere in the file and have no special meaning except possibly to
> various tools. For example, '-compile(Options).' only has a meaning to the
> specific Erlang compiler that you're using; it's not part of the language.
> These are just annotations, and these are the ones that are listed in the
> 'attributes' section of the module info.

