### PR TITLE
Use ppx_expect instead of OUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _build/
 
 *.beam
 !test/*.beam
+
+/tags

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,13 @@ build:
 build-beams:
 	make -C test compile
 
+.PHONY: promote
+promote:
+	dune promote
+
 .PHONY: test-only
 test-only:
-	dune runtest
+	dune runtest test
 
 .PHONY: test
 test: build-beams test-only

--- a/obeam.opam
+++ b/obeam.opam
@@ -11,16 +11,16 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "base"          {>= "v0.11.0"}
-  "stdio"         {>= "v0.11.0"}
-  "bitstring"     {>= "3.0.0"}
-  "camlzip"       {>= "1.07"}
-  "zarith"        {>= "1.7"}
-  "dune"          {build}
-  "ppx_here"      {build}
-  "ppx_let"       {build}
-  "ppx_sexp_conv" {build}
-  "bisect_ppx"    {build}
-  "ounit"         {with-test}
+  "base"                       {>= "v0.11.0"}
+  "stdio"                      {>= "v0.11.0"}
+  "bitstring"                  {>= "3.0.0"}
+  "camlzip"                    {>= "1.07"}
+  "zarith"                     {>= "1.7"}
+  "dune"                       {build}
+  "ppx_here"                   {build}
+  "ppx_let"                    {build}
+  "ppx_sexp_conv"              {build}
+  "bisect_ppx"                 {build}
+  "expect_test_helpers_kernel" {with-test}
 ]
 synopsis: "A utility library for parsing BEAM format"

--- a/test/dune
+++ b/test/dune
@@ -1,11 +1,8 @@
-(executables
- (names abs_form_test)
- (libraries obeam oUnit))
-
-(alias
- (name runtest)
- (deps (:exe abs_form_test.exe) (glob_files *.beam))
- (action (run %{exe})))
+(library
+ (name abs_form_test)
+ (libraries obeam expect_test_helpers_kernel)
+ (inline_tests (deps (glob_files *.beam)))
+ (preprocess (pps ppx_sexp_conv ppx_expect)))
 
 (env
- (dev (flags (:standard -w +42-9-27-39))))
+ (dev (flags (:standard -w -9-27-39))))


### PR DESCRIPTION
ppx_expect pros:
- easy to refine existing tests on implementation changes
- easy to write new tests

ppx_expect cons:
- depends on ppx
- no test status overview output such as `....F..F..`