### PR TITLE
Remove unnecessary TyProduct

### DIFF
--- a/test/test_fun.erl
+++ b/test/test_fun.erl
@@ -12,3 +12,7 @@ g() ->
 -spec h(integer()) -> string().
 h(_) ->
     "abcdefg".
+
+-spec i(integer(), float()) -> string().
+i(_, _) ->
+    "abracadabra".

--- a/test/test_fun.ml
+++ b/test/test_fun.ml
@@ -33,10 +33,7 @@ let%expect_test "test_fun.beam" =
             ()
             h
             1
-            ((
-              TyFun 12
-              (TyProduct 12 ((TyPredef 12 integer ())))
-              (TyPredef 12 string ()))))
+            ((TyFun 12 ((TyPredef 12 integer ())) (TyPredef 12 string ()))))
           (DeclFun
            13
            h
@@ -46,4 +43,23 @@ let%expect_test "test_fun.beam" =
              ((PatUniversal 13))
              ()
              (ExprBody ((ExprLit (LitString 14 abcdefg)))))))
+          (SpecFun 16
+            ()
+            i
+            2
+            ((
+              TyFun 16
+              ((TyPredef 16 integer ())
+               (TyPredef 16 float   ()))
+              (TyPredef 16 string ()))))
+          (DeclFun
+           17
+           i
+           2
+           ((
+             ClsFun 17
+             ((PatUniversal 17)
+              (PatUniversal 17))
+             ()
+             (ExprBody ((ExprLit (LitString 18 abracadabra)))))))
           FormEof)))) |}]


### PR DESCRIPTION
I think `TyProduct` should not belong to `type_t` because only function type uses a simple form `{type, N, product, [...]}` as its intermediate structure.