### PR TITLE
Support char literal

### DIFF
--- a/lib/abstract_format.ml
+++ b/lib/abstract_format.ml
@@ -38,6 +38,7 @@ and form_t =
 
 and literal_t =
   | LitAtom of line_t * string
+  | LitChar of line_t * Uchar.t
   | LitInteger of line_t * int
   | LitBigInt of line_t * Z.t
   | LitString of line_t * string
@@ -377,8 +378,13 @@ and lit_of_sf sf : (literal_t, err_t) Result.t =
   | Sf.Tuple (3, [Sf.Atom "atom"; Sf.Integer line; Sf.Atom v]) ->
      LitAtom (line, v) |> return
 
-  | Sf.Tuple (3, [Sf.Atom "char"; Sf.Integer line; _]) ->
-     failwith "TODO"
+  | Sf.Tuple (3, [Sf.Atom "char"; Sf.Integer line; Sf.Integer c]) ->
+     begin match Uchar.of_scalar c with
+     | None ->
+        Err.create ~loc:[%here] (Err.Invalid_input ("not a valid unicode scalar value", sf)) |> Result.fail
+     | Some u ->
+        LitChar (line, u) |> return
+     end
 
   | Sf.Tuple (3, [Sf.Atom "float"; Sf.Integer line; _]) ->
      failwith "TODO"

--- a/lib/err.ml
+++ b/lib/err.ml
@@ -15,6 +15,7 @@ type 'a t = {
 }
 and 'a kind_t =
   | Not_supported_absform of string * 'a
+  | Invalid_input of string * 'a
 [@@deriving sexp_of]
 
 let create ~loc reason =

--- a/test/test_char.erl
+++ b/test/test_char.erl
@@ -1,0 +1,9 @@
+-module(test_char).
+
+-export([f/0, g/0]).
+
+%% test case for char literal (ASCII)
+f() -> $a.
+
+%% test case for char literal (unicode)
+g() -> $あ.

--- a/test/test_char.ml
+++ b/test/test_char.ml
@@ -1,0 +1,32 @@
+open Test_util
+
+let%expect_test "test_char.beam" =
+  print_ast "test_char.beam";
+  [%expect {|
+    (Ok (
+      AbstractCode (
+        ModDecl (
+          (AttrFile 1 test_char.erl 1)
+          (AttrMod 1 test_char)
+          (AttrExport 3 (
+            (f 0)
+            (g 0)))
+          (DeclFun
+           6
+           f
+           0
+           ((
+             ClsFun 6
+             ()
+             ()
+             (ExprBody ((ExprLit (LitChar 6 U+0061)))))))
+          (DeclFun
+           9
+           g
+           0
+           ((
+             ClsFun 9
+             ()
+             ()
+             (ExprBody ((ExprLit (LitChar 9 U+3042)))))))
+          FormEof)))) |}]


### PR DESCRIPTION
resolves #67 

I used [User.t of base library](https://github.com/janestreet/base/blob/master/src/uchar.mli) because [Erlang's char is unicode](http://erlang.org/doc/reference_manual/data_types.html#number).