### PR TITLE
Support Record syntax in Guard tests

### DIFF
--- a/lib/abstract_format.ml
+++ b/lib/abstract_format.ml
@@ -111,12 +111,18 @@ and guard_test_t =
   | GuardTestMapCreation of {line: line_t; assocs: guard_test_assoc_t list}
   | GuardTestMapUpdate of {line: line_t; map: guard_test_t; assocs: guard_test_assoc_t list}
   | GuardTestBinOp of {line: line_t; op: string; lhs: guard_test_t; rhs: guard_test_t}
+  | GuardTestRecord of {line: line_t; name: string; record_fields: (line_t * atom_or_wildcard * guard_test_t) list}
+  | GuardTestRecordFieldAccess of {line: line_t; record: guard_test_t; name: string; field_name: string}
+  | GuardTestRecordFieldIndex of {line: line_t; name: string; field_name: string}
   | GuardTestTuple of {line: line_t; elements: guard_test_t list}
   | GuardTestVar of {line: line_t; id: string}
   | GuardTestLit of {lit: literal_t}
 and guard_test_assoc_t =
   | GuardTestAssoc of {line: line_t; key: guard_test_t; value: guard_test_t}
   | GuardTestAssocExact of {line: line_t; key: guard_test_t; value: guard_test_t}
+and atom_or_wildcard = (* atom or _ for the fields of a record creation in guard tests *)
+  | AtomWildcardAtom of string
+  | AtomWildcardWildcard
 
 and type_t =
   | TyAnn of {line: line_t; annotation: type_t; tyvar: type_t}
@@ -909,6 +915,43 @@ and guard_test_of_sf sf : (guard_test_t, err_t) Result.t =
      let%bind rhs = sf_rhs |> guard_test_of_sf |> track ~loc:[%here] in
      GuardTestBinOp {line; op; lhs; rhs} |> return
 
+  (* a record creation : #user{name = "Taro", admin = true} *)
+  | Sf.Tuple (4, [Sf.Atom "record";
+                  Sf.Integer line;
+                  Sf.Atom name;
+                  Sf.List sf_record_fields]) ->
+     let field_of_sf sf =
+       begin match sf with
+       | Sf.Tuple (4, [Sf.Atom "record_field";
+                       Sf.Integer line;
+                       sf_atom_or_wildcard;
+                       sf_guard_test]) ->
+          let%bind field_name = atom_or_wildcard_of_sf sf_atom_or_wildcard in
+          let%bind rhs = guard_test_of_sf sf_guard_test in
+          (line, field_name, rhs) |> return
+       | _ ->
+          Err.create ~loc:[%here] (Err.Not_supported_absform ("cannot reach here", sf)) |> Result.fail
+       end
+     in
+     let%bind record_fields = sf_record_fields |> List.map ~f:field_of_sf |> Result.all |> track ~loc:[%here] in
+     GuardTestRecord {line; name; record_fields} |> return
+
+  (* a record field access : U#user.name *)
+  | Sf.Tuple (5, [Sf.Atom "record_field";
+                  Sf.Integer line;
+                  sf_record;
+                  Sf.Atom name;
+                  Sf.Tuple (3, [Sf.Atom "atom"; _; Sf.Atom field_name])]) ->
+     let%bind record = sf_record |> guard_test_of_sf |> track ~loc:[%here] in
+     GuardTestRecordFieldAccess {line; record; name; field_name} |> return
+
+  (* a record field index : #user.name *)
+  | Sf.Tuple (4, [Sf.Atom "record_index";
+                  Sf.Integer line;
+                  Sf.Atom name;
+                  Sf.Tuple (3, [Sf.Atom "atom"; _; Sf.Atom field_name])]) ->
+     GuardTestRecordFieldIndex {line; name; field_name} |> return
+
   (* a tuple skeleton *)
   | Sf.Tuple (3, [Sf.Atom "tuple"; Sf.Integer line; Sf.List sf_elements]) ->
      let%bind elements = sf_elements |> List.map ~f:guard_test_of_sf |> Result.all |> track ~loc:[%here] in
@@ -940,6 +983,15 @@ and guard_test_assoc_of_sf sf : (guard_test_assoc_t, err_t) Result.t =
 
   | _ ->
      Err.create ~loc:[%here] (Err.Not_supported_absform ("guard_test_assoc", sf)) |> Result.fail
+
+and atom_or_wildcard_of_sf sf =
+  match sf with
+  | Sf.Tuple (3, [Sf.Atom "atom"; _; Sf.Atom field_name]) ->
+     AtomWildcardAtom field_name |> Result.return
+  | Sf.Tuple (3, [Sf.Atom "var"; _; Sf.Atom "_"]) ->
+     AtomWildcardWildcard |> Result.return
+  | _ ->
+     Err.create ~loc:[%here] (Err.Not_supported_absform ("atom_or_wildcard", sf)) |> Result.fail
 
 (*
  * 8.7  Types

--- a/test/test_record.erl
+++ b/test/test_record.erl
@@ -6,10 +6,19 @@
             c :: string(),
             d = 57 :: integer()}).
 
--export([f/0]).
+-export([f/0, g/1]).
 
 f() ->
     R = #r{a = 3, c = "hello"}, % Record Creation
     _ = R#r.c,                  % Record Field Access
     Index = #r.b,               % Record Field Index
     R#r{a = 100, c = "hoge"}.   % Record Update
+
+g(R) ->
+    _ =
+        case R of
+            _ when #r{a = true, _ = 111} -> foo; % Record Creation in Guard test
+            _ when R#r.b -> bar;                 % Record Field Access in Guard test
+            _ when #r.c -> baz                   % Record Field Index in Guard test
+        end,
+    ok.

--- a/test/test_record.ml
+++ b/test/test_record.ml
@@ -54,7 +54,11 @@ let%expect_test "test_record.beam" =
                       LitInteger
                       (line    7)
                       (integer 57))))))))))
-          (AttrExport (line 9) (function_arity_list ((f 0))))
+          (AttrExport
+            (line 9)
+            (function_arity_list (
+              (f 0)
+              (g 1))))
           (DeclFun
             (line          11)
             (function_name f)
@@ -133,4 +137,112 @@ let%expect_test "test_record.beam" =
                               LitString
                               (line 15)
                               (str  hoge))))))))))))))))
+          (DeclFun
+            (line          17)
+            (function_name g)
+            (arity         1)
+            (clauses ((
+              ClsFun
+              (line 17)
+              (patterns ((
+                PatVar
+                (line 17)
+                (id   R))))
+              (guard_sequence ())
+              (body (
+                ExprBody (
+                  exprs (
+                    (ExprMatch
+                      (line 18)
+                      (pattern (PatUniversal (line 18)))
+                      (body (
+                        ExprCase
+                        (line 19)
+                        (expr (
+                          ExprVar
+                          (line 19)
+                          (id   R)))
+                        (clauses (
+                          (ClsCase
+                            (line 20)
+                            (pattern (PatUniversal (line 20)))
+                            (guard_sequence ((
+                              GuardSeq (
+                                guards ((
+                                  Guard (
+                                    guard_tests ((
+                                      GuardTestRecord
+                                      (line 20)
+                                      (name r)
+                                      (record_fields (
+                                        (20
+                                          (AtomWildcardAtom a)
+                                          (GuardTestLit (
+                                            lit (
+                                              LitAtom
+                                              (line 20)
+                                              (atom true)))))
+                                        (20 AtomWildcardWildcard (
+                                          GuardTestLit (
+                                            lit (
+                                              LitInteger
+                                              (line    20)
+                                              (integer 111))))))))))))))))
+                            (body (
+                              ExprBody (
+                                exprs ((
+                                  ExprLit (
+                                    lit (
+                                      LitAtom
+                                      (line 20)
+                                      (atom foo)))))))))
+                          (ClsCase
+                            (line 21)
+                            (pattern (PatUniversal (line 21)))
+                            (guard_sequence ((
+                              GuardSeq (
+                                guards ((
+                                  Guard (
+                                    guard_tests ((
+                                      GuardTestRecordFieldAccess
+                                      (line 21)
+                                      (record (
+                                        GuardTestVar
+                                        (line 21)
+                                        (id   R)))
+                                      (name       r)
+                                      (field_name b))))))))))
+                            (body (
+                              ExprBody (
+                                exprs ((
+                                  ExprLit (
+                                    lit (
+                                      LitAtom
+                                      (line 21)
+                                      (atom bar)))))))))
+                          (ClsCase
+                            (line 22)
+                            (pattern (PatUniversal (line 22)))
+                            (guard_sequence ((
+                              GuardSeq (
+                                guards ((
+                                  Guard (
+                                    guard_tests ((
+                                      GuardTestRecordFieldIndex
+                                      (line       22)
+                                      (name       r)
+                                      (field_name c))))))))))
+                            (body (
+                              ExprBody (
+                                exprs ((
+                                  ExprLit (
+                                    lit (
+                                      LitAtom
+                                      (line 22)
+                                      (atom baz))))))))))))))
+                    (ExprLit (
+                      lit (
+                        LitAtom
+                        (line 24)
+                        (atom ok))))))))))))
           FormEof)))) |}]

--- a/test/test_record.ml
+++ b/test/test_record.ml
@@ -176,14 +176,17 @@ let%expect_test "test_record.beam" =
                                       (name r)
                                       (record_fields (
                                         (20
-                                          (AtomWildcardAtom a)
+                                          (AtomWildcardAtom
+                                            (line 20)
+                                            (atom a))
                                           (GuardTestLit (
                                             lit (
                                               LitAtom
                                               (line 20)
                                               (atom true)))))
-                                        (20 AtomWildcardWildcard (
-                                          GuardTestLit (
+                                        (20
+                                          (AtomWildcardWildcard (line 20))
+                                          (GuardTestLit (
                                             lit (
                                               LitInteger
                                               (line    20)
@@ -210,8 +213,9 @@ let%expect_test "test_record.beam" =
                                         GuardTestVar
                                         (line 21)
                                         (id   R)))
-                                      (name       r)
-                                      (field_name b))))))))))
+                                      (name            r)
+                                      (line_field_name 21)
+                                      (field_name      b))))))))))
                             (body (
                               ExprBody (
                                 exprs ((
@@ -229,9 +233,10 @@ let%expect_test "test_record.beam" =
                                   Guard (
                                     guard_tests ((
                                       GuardTestRecordFieldIndex
-                                      (line       22)
-                                      (name       r)
-                                      (field_name c))))))))))
+                                      (line            22)
+                                      (name            r)
+                                      (line_field_name 22)
+                                      (field_name      c))))))))))
                             (body (
                               ExprBody (
                                 exprs ((


### PR DESCRIPTION
for #54 

- record creation in guard test
- record field access in guard test
- record field index in guard test

## Example

```erlang
        case R of
            _ when #r{a = true, _ = 111} -> foo; % Record Creation in Guard test
            _ when R#r.b -> bar;                 % Record Field Access in Guard test
            _ when #r.c -> baz                   % Record Field Index in Guard test
        end,
```