### PR TITLE
Record patterns

### DIFF
--- a/lib/abstract_format.ml
+++ b/lib/abstract_format.ml
@@ -50,7 +50,7 @@ and pattern_t =
   | PatCons of {line: line_t; head: pattern_t; tail: pattern_t}
   | PatNil of {line: line_t}
   | PatMap of {line: line_t;  assocs: pattern_assoc_t list}
-  | PatRecordFieldIndex of {line: line_t; name: string; field_name: string}
+  | PatRecordFieldIndex of {line: line_t; name: string; line_field_name: line_t; field_name: string}
   | PatRecord of {line: line_t; name: string; record_fields: (line_t * atom_or_wildcard * pattern_t) list}
   | PatTuple of {line: line_t; pats: pattern_t list}
   | PatUniversal of {line: line_t}
@@ -452,8 +452,8 @@ and pat_of_sf sf : (pattern_t, err_t) Result.t =
   | Sf.Tuple (4, [Sf.Atom "record_index";
                   Sf.Integer line;
                   Sf.Atom name;
-                  Sf.Tuple (3, [Sf.Atom "atom"; _; Sf.Atom field_name])]) ->
-     PatRecordFieldIndex {line; name; field_name} |> return
+                  Sf.Tuple (3, [Sf.Atom "atom"; Sf.Integer line_field_name; Sf.Atom field_name])]) ->
+     PatRecordFieldIndex {line; name; line_field_name; field_name} |> return
 
   (* a record pattern : #user{name = "Taro", admin = true} *)
   | Sf.Tuple (4, [Sf.Atom "record";

--- a/lib/abstract_format.ml
+++ b/lib/abstract_format.ml
@@ -466,8 +466,8 @@ and pat_of_sf sf : (pattern_t, err_t) Result.t =
                        Sf.Integer line;
                        sf_atom_or_wildcard;
                        sf_pattern]) ->
-          let%bind field_name = atom_or_wildcard_of_sf sf_atom_or_wildcard in
-          let%bind rhs = pat_of_sf sf_pattern in
+          let%bind field_name = atom_or_wildcard_of_sf sf_atom_or_wildcard |> track ~loc:[%here] in
+          let%bind rhs = pat_of_sf sf_pattern |> track ~loc:[%here] in
           (line, field_name, rhs) |> return
        | _ ->
           Err.create ~loc:[%here] (Err.Not_supported_absform ("cannot reach here", sf)) |> Result.fail

--- a/lib/abstract_format.ml
+++ b/lib/abstract_format.ml
@@ -470,7 +470,7 @@ and pat_of_sf sf : (pattern_t, err_t) Result.t =
           let%bind rhs = pat_of_sf sf_pattern |> track ~loc:[%here] in
           (line, field_name, rhs) |> return
        | _ ->
-          Err.create ~loc:[%here] (Err.Not_supported_absform ("cannot reach here", sf)) |> Result.fail
+          Err.create ~loc:[%here] (Err.Invalid_input ("invalid form of a field of record pattern", sf)) |> Result.fail
        end
      in
      let%bind record_fields = sf_record_fields |> List.map ~f:field_of_sf |> Result.all |> track ~loc:[%here] in

--- a/test/test_record.erl
+++ b/test/test_record.erl
@@ -21,4 +21,9 @@ g(R) ->
             _ when R#r.b -> bar;                 % Record Field Access in Guard test
             _ when #r.c -> baz                   % Record Field Index in Guard test
         end,
+    _ =
+        case R of
+            #r.a -> foo;                 % Record Field Index Pattern
+            #r{a = true, _ = 111} -> bar % Record Pattern
+        end,
     ok.

--- a/test/test_record.ml
+++ b/test/test_record.ml
@@ -245,9 +245,65 @@ let%expect_test "test_record.beam" =
                                       LitAtom
                                       (line 22)
                                       (atom baz))))))))))))))
+                    (ExprMatch
+                      (line 24)
+                      (pattern (PatUniversal (line 24)))
+                      (body (
+                        ExprCase
+                        (line 25)
+                        (expr (
+                          ExprVar
+                          (line 25)
+                          (id   R)))
+                        (clauses (
+                          (ClsCase
+                            (line 26)
+                            (pattern (
+                              PatRecordFieldIndex
+                              (line       26)
+                              (name       r)
+                              (field_name a)))
+                            (guard_sequence ())
+                            (body (
+                              ExprBody (
+                                exprs ((
+                                  ExprLit (
+                                    lit (
+                                      LitAtom
+                                      (line 26)
+                                      (atom foo)))))))))
+                          (ClsCase
+                            (line 27)
+                            (pattern (
+                              PatRecord
+                              (line 27)
+                              (name r)
+                              (record_fields (
+                                (27
+                                  (AtomWildcardAtom a)
+                                  (PatLit (
+                                    lit (
+                                      LitAtom
+                                      (line 27)
+                                      (atom true)))))
+                                (27 AtomWildcardWildcard (
+                                  PatLit (
+                                    lit (
+                                      LitInteger
+                                      (line    27)
+                                      (integer 111)))))))))
+                            (guard_sequence ())
+                            (body (
+                              ExprBody (
+                                exprs ((
+                                  ExprLit (
+                                    lit (
+                                      LitAtom
+                                      (line 27)
+                                      (atom bar))))))))))))))
                     (ExprLit (
                       lit (
                         LitAtom
-                        (line 24)
+                        (line 29)
                         (atom ok))))))))))))
           FormEof)))) |}]

--- a/test/test_record.ml
+++ b/test/test_record.ml
@@ -260,9 +260,10 @@ let%expect_test "test_record.beam" =
                             (line 26)
                             (pattern (
                               PatRecordFieldIndex
-                              (line       26)
-                              (name       r)
-                              (field_name a)))
+                              (line            26)
+                              (name            r)
+                              (line_field_name 26)
+                              (field_name      a)))
                             (guard_sequence ())
                             (body (
                               ExprBody (
@@ -280,14 +281,17 @@ let%expect_test "test_record.beam" =
                               (name r)
                               (record_fields (
                                 (27
-                                  (AtomWildcardAtom a)
+                                  (AtomWildcardAtom
+                                    (line 27)
+                                    (atom a))
                                   (PatLit (
                                     lit (
                                       LitAtom
                                       (line 27)
                                       (atom true)))))
-                                (27 AtomWildcardWildcard (
-                                  PatLit (
+                                (27
+                                  (AtomWildcardWildcard (line 27))
+                                  (PatLit (
                                     lit (
                                       LitInteger
                                       (line    27)


### PR DESCRIPTION
Support

- Record Field Index Pattern
- Record Pattern

for #54 

## code diffs

see https://github.com/yoshihiro503/obeam/compare/record_in_guard_tests...yoshihiro503:record_patterns

## example

```erlang
        case R of
            #r.a -> foo;                 % Record Field Index Pattern
            #r{a = true, _ = 111} -> bar % Record Pattern
        end,
```

## dependencies

~This is depends on https://github.com/yutopp/obeam/pull/76~
rebased: https://github.com/yutopp/obeam/compare/a642ab01f1bd4ebb4f065a743807000f1c984c0f..8f6bc508c60a89d034f66b045d9e5d40b30eeb73