### PR TITLE
Support Record type

### DIFF
--- a/lib/abstract_format.ml
+++ b/lib/abstract_format.ml
@@ -132,7 +132,7 @@ and type_t =
   | TyFunAnyArity of {line: line_t; line_any: line_t; ret: type_t}
   | TyContFun of {line: line_t; function_type: type_t; constraints: type_func_cont_t}
   | TyFun of {line: line_t; line_params: line_t; params: type_t list; ret: type_t}
-  | TyRecord of {line: line_t; name: string; line_field_types: line_t; field_types: record_field_type_t list}
+  | TyRecord of {line: line_t; line_name: line_t; name: string; field_types: record_field_type_t list}
   | TyAnyTuple of {line: line_t}
   | TyTuple of {line: line_t; elements: type_t list}
   | TyUnion of {line: line_t; elements: type_t list}
@@ -1035,10 +1035,10 @@ and type_of_sf sf : (type_t, err_t) Result.t =
                   Sf.Integer line;
                   Sf.Atom "record";
                   Sf.List (
-                      Sf.Tuple(3, [Sf.Atom "atom"; Sf.Integer line_field_types; Sf.Atom name])
+                      Sf.Tuple(3, [Sf.Atom "atom"; Sf.Integer line_name; Sf.Atom name])
                       :: sf_field_types)]) ->
      let%bind field_types = sf_field_types |> List.map ~f:record_field_type_of_sf |> Result.all |> track ~loc:[%here] in
-     TyRecord {line; name; line_field_types; field_types} |> return
+     TyRecord {line; line_name; name; field_types} |> return
 
   (* tuple type (any) *)
   | Sf.Tuple (4, [Sf.Atom "type"; Sf.Integer line; Sf.Atom "tuple"; Sf.Atom "any"]) ->

--- a/test/test_type_attr.erl
+++ b/test/test_type_attr.erl
@@ -7,3 +7,6 @@
 
 %% test case for opaque decl
 -opaque int() :: integer().
+
+-record(state, {name :: string(), param :: term()}).
+-type record_as_type(A) :: #state{param :: A}.

--- a/test/test_type_attr.erl
+++ b/test/test_type_attr.erl
@@ -8,5 +8,6 @@
 %% test case for opaque decl
 -opaque int() :: integer().
 
+%% test case for record type and record field type
 -record(state, {name :: string(), param :: term()}).
 -type record_as_type(A) :: #state{param :: A}.

--- a/test/test_type_attr.ml
+++ b/test/test_type_attr.ml
@@ -40,42 +40,42 @@ let%expect_test "test_type_attr.beam" =
               (name integer)
               (args ()))))
           (DeclRecord
-            (line 11)
+            (line 12)
             (fields (
               (RecordField
-                (line       11)
+                (line       12)
                 (field_name name)
                 (ty ((
                   TyPredef
-                  (line 11)
+                  (line 12)
                   (name string)
                   (args ()))))
                 (default_expr ()))
               (RecordField
-                (line       11)
+                (line       12)
                 (field_name param)
                 (ty ((
                   TyPredef
-                  (line 11)
+                  (line 12)
                   (name term)
                   (args ()))))
                 (default_expr ())))))
           (DeclType
-            (line 12)
+            (line 13)
             (name record_as_type)
-            (tvars ((12 A)))
+            (tvars ((13 A)))
             (ty (
               TyRecord
-              (line             12)
+              (line             13)
               (name             state)
-              (line_field_types 12)
+              (line_field_types 13)
               (field_types ((
                 RecordFieldType
-                (line      12)
-                (line_name 12)
+                (line      13)
+                (line_name 13)
                 (name      param)
                 (ty (
                   TyVar
-                  (line 12)
+                  (line 13)
                   (id   A)))))))))
           FormEof)))) |}]

--- a/test/test_type_attr.ml
+++ b/test/test_type_attr.ml
@@ -66,9 +66,9 @@ let%expect_test "test_type_attr.beam" =
             (tvars ((13 A)))
             (ty (
               TyRecord
-              (line             13)
-              (name             state)
-              (line_field_types 13)
+              (line      13)
+              (line_name 13)
+              (name      state)
               (field_types ((
                 RecordFieldType
                 (line      13)

--- a/test/test_type_attr.ml
+++ b/test/test_type_attr.ml
@@ -39,4 +39,43 @@ let%expect_test "test_type_attr.beam" =
               (line 9)
               (name integer)
               (args ()))))
+          (DeclRecord
+            (line 11)
+            (fields (
+              (RecordField
+                (line       11)
+                (field_name name)
+                (ty ((
+                  TyPredef
+                  (line 11)
+                  (name string)
+                  (args ()))))
+                (default_expr ()))
+              (RecordField
+                (line       11)
+                (field_name param)
+                (ty ((
+                  TyPredef
+                  (line 11)
+                  (name term)
+                  (args ()))))
+                (default_expr ())))))
+          (DeclType
+            (line 12)
+            (name record_as_type)
+            (tvars ((12 A)))
+            (ty (
+              TyRecord
+              (line             12)
+              (name             state)
+              (line_field_types 12)
+              (field_types ((
+                RecordFieldType
+                (line      12)
+                (line_name 12)
+                (name      param)
+                (ty (
+                  TyVar
+                  (line 12)
+                  (id   A)))))))))
           FormEof)))) |}]


### PR DESCRIPTION
Support

- record types
- record field type

See also #54 

## Example
```
-record(state, {name :: string(), param :: term()}).
-type record_as_type(A) :: #state{param :: A}.
```