### PR TITLE
Support Remote type

### DIFF
--- a/test/test_type_attr.erl
+++ b/test/test_type_attr.erl
@@ -11,3 +11,6 @@
 %% test case for record type and record field type
 -record(state, {name :: string(), param :: term()}).
 -type record_as_type(A) :: #state{param :: A}.
+
+%% test case for remote type
+-type some_remote(A) :: dict:dict(integer(), A).

--- a/test/test_type_attr.ml
+++ b/test/test_type_attr.ml
@@ -80,4 +80,23 @@ let%expect_test "test_type_attr.beam" =
                   TyVar
                   (line 13)
                   (id   A)))))))))
+          (DeclType
+            (line 16)
+            (name some_remote)
+            (tvars ((16 A)))
+            (ty (
+              TyRemote
+              (line             16)
+              (line_module_name 16)
+              (module_name      dict)
+              (line_type_name   16)
+              (type_name        dict)
+              (params (
+                (TyPredef
+                  (line 16)
+                  (name integer)
+                  (args ()))
+                (TyVar
+                  (line 16)
+                  (id   A)))))))
           FormEof)))) |}]


### PR DESCRIPTION
Support
- remote type

## Example
```erlang
-type some_remote(A) :: dict:dict(integer(), A).
```