### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/obeam.opam
+++ b/obeam.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "obeam"
-version: "0.1.3"
+version: "0.1.4"
 maintainer: "yutopp <yutopp@gmail.com>"
 authors: ["yutopp <yutopp@gmail.com>" "amutake <amutake.s@gmail.com>"]
 homepage: "https://github.com/yutopp/obeam"


### PR DESCRIPTION
I think it's time to release because all absforms are implemented!

confirmation: Is the version `0.1.4` OK? Should be `0.2.0` or `1.0.0`?